### PR TITLE
Fixes deprecated get_app_proxy_type

### DIFF
--- a/proxy-build-config
+++ b/proxy-build-config
@@ -10,7 +10,7 @@ haproxy_proxy_build_config() {
   local trigger="haproxy_proxy_build_config"
   local APP="$1" ACTION="$2"
 
-  if [[ "$(get_app_proxy_type "$APP")" == "haproxy" ]]; then
+  if [[ "$(plugn trigger proxy-type "$APP")" == "haproxy" ]]; then
     add_tcp_ports_from_dockerfile "$APP"
     haproxy_build_config "$APP"
     haproxy_reload

--- a/proxy-disable
+++ b/proxy-disable
@@ -10,7 +10,7 @@ haproxy_proxy_disable() {
   local trigger="haproxy_proxy_disable"
   local APP="$1" ACTION="$2"
 
-  if [[ "$(get_app_proxy_type "$APP")" == "haproxy" ]]; then
+  if [[ "$(plugn trigger proxy-type "$APP")" == "haproxy" ]]; then
     haproxy_delete_config "$APP"
     haproxy_reload
   fi

--- a/proxy-enable
+++ b/proxy-enable
@@ -10,7 +10,7 @@ haproxy_proxy_enable() {
   local trigger="haproxy_proxy_enable"
   local APP="$1" ACTION="$2"
 
-  if [[ "$(get_app_proxy_type "$APP")" == "haproxy" ]]; then
+  if [[ "$(plugn trigger proxy-type "$APP")" == "haproxy" ]]; then
     add_tcp_ports_from_dockerfile "$APP"
     haproxy_build_config "$APP"
     haproxy_reload


### PR DESCRIPTION
replaces `get_app_proxy_type` for `plugn trigger proxy-type "$APP"`